### PR TITLE
Add a "compact mode" UI setting

### DIFF
--- a/src/lib/components/ListEditor.svelte
+++ b/src/lib/components/ListEditor.svelte
@@ -4,6 +4,8 @@
 	import CloseOutline from "carbon-icons-svelte/lib/CloseOutline.svelte"
 	import Edit from "carbon-icons-svelte/lib/Edit.svelte"
 	import AddAlt from "carbon-icons-svelte/lib/AddAlt.svelte"
+	
+	import { appSettings } from "$lib/stores"
 
 	import { createEventDispatcher } from "svelte"
 
@@ -16,6 +18,8 @@
 	let newValueInputModal: TextInputModal
 	let newValueInputModalOpen = false
 	let valueToEdit = ""
+
+	const padding = $appSettings.compactMode ? "py-0.5 px-2" : "py-2 px-4"
 </script>
 
 <br />
@@ -23,7 +27,7 @@
 	<tbody>
 		{#each data as value, index (value)}
 			<tr class:border-b={index != data.length - 1} class="border-solid border-b-white">
-				<td class="p-2 px-4 text-[#f4f4f4]">
+				<td class="{padding} text-[#f4f4f4]">
 					<div class="flex flex-row gap-4 items-center">
 						<code class="flex-grow break-all">{value}</code>
 						<Button
@@ -53,7 +57,7 @@
 		{/each}
 		{#if data.length == 0}
 			<tr class="border-solid border-b-white">
-				<td class="p-2 px-4 text-[#f4f4f4]">
+				<td class="{padding} text-[#f4f4f4]">
 					<div class="flex flex-row gap-4 items-center">
 						<code class="flex-grow">No entries</code>
 					</div>

--- a/src/lib/components/ListEditor.svelte
+++ b/src/lib/components/ListEditor.svelte
@@ -4,7 +4,7 @@
 	import CloseOutline from "carbon-icons-svelte/lib/CloseOutline.svelte"
 	import Edit from "carbon-icons-svelte/lib/Edit.svelte"
 	import AddAlt from "carbon-icons-svelte/lib/AddAlt.svelte"
-	
+
 	import { appSettings } from "$lib/stores"
 
 	import { createEventDispatcher } from "svelte"

--- a/src/lib/components/MonacoEditor.svelte
+++ b/src/lib/components/MonacoEditor.svelte
@@ -79,7 +79,7 @@
 			theme: "theme",
 			minimap: {
 				enabled: !$appSettings.compactMode
-			},
+			}
 		})
 
 		if (inVivoExtensions) {

--- a/src/lib/components/MonacoEditor.svelte
+++ b/src/lib/components/MonacoEditor.svelte
@@ -76,7 +76,10 @@
 		editor = Monaco.editor.create(el, {
 			model,
 			roundedSelection: false,
-			theme: "theme"
+			theme: "theme",
+			minimap: {
+				enabled: !$appSettings.compactMode
+			},
 		})
 
 		if (inVivoExtensions) {

--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -50,7 +50,7 @@ await forage.setItem({
 				preferredHighlightColour: "#0000ff",
 				extractModdedFiles: false,
 				h1: false,
-				compactMode: false,
+				compactMode: false
 			},
 			json.parse((await forage.getItem({ key: "appSettings" })()) || "{}")
 		)

--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -28,6 +28,7 @@ interface AppSettings {
 	logRocketName: string
 
 	technicalMode: boolean
+	compactMode: boolean
 }
 
 await forage.setItem({
@@ -48,7 +49,8 @@ await forage.setItem({
 				autoSaveOnSwitchFile: true,
 				preferredHighlightColour: "#0000ff",
 				extractModdedFiles: false,
-				h1: false
+				h1: false,
+				compactMode: false,
 			},
 			json.parse((await forage.getItem({ key: "appSettings" })()) || "{}")
 		)

--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -1261,8 +1261,8 @@
 			</SideNavItems>
 		</SideNav>
 	</header>
-	<Content class={ $appSettings.compactMode ? "compact" : "" }>
-		<div class={ $appSettings.compactMode ? "h-[calc(100vh-2rem)]" : "px-16 h-[90vh]" }>
+	<Content class={$appSettings.compactMode ? "compact" : ""}>
+		<div class={$appSettings.compactMode ? "h-[calc(100vh-2rem)]" : "px-16 h-[90vh]"}>
 			<SplitPanes theme="">
 				{#if $workspaceData.path}
 					<Pane size={15}>
@@ -1545,7 +1545,9 @@
 		min-height: auto;
 	}
 
-	.compact .bx--search-input, .compact .bx--text-input, .bx--select-input {
+	.compact .bx--search-input,
+	.compact .bx--text-input,
+	.bx--select-input {
 		height: 2rem;
 	}
 
@@ -1571,7 +1573,7 @@
 		height: 2rem;
 	}
 
-	.bx--header.compact~.bx--content {
+	.bx--header.compact ~ .bx--content {
 		margin-top: 2rem;
 	}
 
@@ -1586,5 +1588,4 @@
 	.compact a.bx--side-nav__link {
 		padding: 0 0.5rem;
 	}
-
 </style>

--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -429,7 +429,7 @@
 </script>
 
 {#if ready}
-	<header data-tauri-drag-region class:bx--header={true}>
+	<header data-tauri-drag-region class:bx--header={true} class:compact={$appSettings.compactMode}>
 		<SkipToContent />
 		<!-- svelte-ignore a11y-missing-attribute -->
 		<a data-tauri-drag-region class:bx--header__name={true}>
@@ -1173,7 +1173,7 @@
 			</div>
 		</div>
 
-		<SideNav bind:isOpen={isSideNavOpen} rail>
+		<SideNav bind:isOpen={isSideNavOpen} rail class={$appSettings.compactMode ? "compact" : ""}>
 			<SideNavItems>
 				<SideNavLink
 					icon={Data2}
@@ -1261,8 +1261,8 @@
 			</SideNavItems>
 		</SideNav>
 	</header>
-	<Content>
-		<div class="px-16 h-[90vh]">
+	<Content class={ $appSettings.compactMode ? "compact" : "" }>
+		<div class={ $appSettings.compactMode ? "h-[calc(100vh-2rem)]" : "px-16 h-[90vh]" }>
 			<SplitPanes theme="">
 				{#if $workspaceData.path}
 					<Pane size={15}>
@@ -1534,4 +1534,57 @@
 	.bx--tree .bx--tree-node {
 		background-color: inherit;
 	}
+
+	/* Compact mode styles */
+	.bx--content.compact {
+		padding: 0 0 0 2rem;
+	}
+
+	.compact .bx--tile {
+		padding: 0.2rem;
+		min-height: auto;
+	}
+
+	.compact .bx--search-input, .compact .bx--text-input, .bx--select-input {
+		height: 2rem;
+	}
+
+	.compact .bx--btn {
+		min-height: auto;
+		padding-top: 0.2rem;
+		padding-bottom: 0.2rem;
+	}
+
+	.compact h1 {
+		font-size: 1.75rem;
+	}
+
+	.compact h2 {
+		font-size: 1.5rem;
+	}
+
+	.compact h3 {
+		font-size: 1.3rem;
+	}
+
+	.bx--header.compact {
+		height: 2rem;
+	}
+
+	.bx--header.compact~.bx--content {
+		margin-top: 2rem;
+	}
+
+	.compact .bx--side-nav--rail {
+		width: 2rem;
+	}
+
+	.compact .bx--side-nav--ux {
+		top: 2rem;
+	}
+
+	.compact a.bx--side-nav__link {
+		padding: 0 0.5rem;
+	}
+
 </style>

--- a/src/routes/settings.svelte
+++ b/src/routes/settings.svelte
@@ -128,4 +128,15 @@
 		<TextInput labelText="Identifier for reporting" placeholder={"EpicGamer123 (leave blank to be anonymous)"} bind:value={$appSettings.logRocketName} />
 		<br />
 	{/if}
+	<div class="flex items-center gap-2">
+		<div class="flex-shrink">
+			<Checkbox bind:checked={$appSettings.compactMode} labelText="Enable compact mode" />
+		</div>
+		<TooltipIcon icon={Information}>
+			<span slot="tooltipText" style="font-size: 0.875rem; margin-top: 0.5rem; margin-bottom: 0.5rem">
+				Reduce whitespace and make the UI more compact.
+			</span>
+		</TooltipIcon>
+	</div>
+	<br />
 </div>

--- a/src/routes/settings.svelte
+++ b/src/routes/settings.svelte
@@ -40,6 +40,15 @@
 		</TooltipIcon>
 	</div>
 	<br />
+	<div class="flex items-center gap-2">
+		<div class="flex-shrink">
+			<Checkbox bind:checked={$appSettings.compactMode} labelText="Enable compact mode" />
+		</div>
+		<TooltipIcon icon={Information}>
+			<span slot="tooltipText" style="font-size: 0.875rem; margin-top: 0.5rem; margin-bottom: 0.5rem">Reduces whitespace and makes the UI more compact.</span>
+		</TooltipIcon>
+	</div>
+	<br />
 	<Checkbox bind:checked={$appSettings.autoSaveOnSwitchFile} labelText="Automatically save when switching workspace files" />
 	<br />
 	<Checkbox bind:checked={$appSettings.extractModdedFiles} labelText="Load modded versions when loading from game files" />
@@ -128,15 +137,4 @@
 		<TextInput labelText="Identifier for reporting" placeholder={"EpicGamer123 (leave blank to be anonymous)"} bind:value={$appSettings.logRocketName} />
 		<br />
 	{/if}
-	<div class="flex items-center gap-2">
-		<div class="flex-shrink">
-			<Checkbox bind:checked={$appSettings.compactMode} labelText="Enable compact mode" />
-		</div>
-		<TooltipIcon icon={Information}>
-			<span slot="tooltipText" style="font-size: 0.875rem; margin-top: 0.5rem; margin-bottom: 0.5rem">
-				Reduce whitespace and make the UI more compact.
-			</span>
-		</TooltipIcon>
-	</div>
-	<br />
 </div>

--- a/src/routes/tree.svelte
+++ b/src/routes/tree.svelte
@@ -174,13 +174,15 @@
 	let helpMenuOutputs: string[] = []
 
 	let editorComponent: MonacoEditor
+
+	const padding = $appSettings.compactMode ? "p-1" : "p-2 px-3"
 </script>
 
 <SplitPanes on:resize={() => editor?.layout()} theme="">
 	<Pane>
 		<SplitPanes on:resize={() => editor?.layout()} theme="" horizontal={true}>
 			<Pane>
-				<div class="flex flex-col h-full shepherd-tree p-2 px-3">
+				<div class="flex flex-col h-full shepherd-tree {padding}">
 					<div class="flex flex-row gap-4 items-center">
 						<h1>Tree</h1>
 						<div class="flex-grow flex flex-row gap-2 items-center">
@@ -356,7 +358,7 @@
 				</div>
 			</Pane>
 			<Pane>
-				<div class="flex flex-col h-full shepherd-information p-2 px-3">
+				<div class="flex flex-col h-full shepherd-information {padding}">
 					<h1>Information</h1>
 					<div class="flex-grow overflow-y-auto overflow-x-hidden pr-2">
 						{#if selectionType}
@@ -475,7 +477,7 @@
 		</SplitPanes>
 	</Pane>
 	<Pane>
-		<div class="flex flex-col h-full shepherd-editor p-2 px-3">
+		<div class="flex flex-col h-full shepherd-editor {padding}">
 			{#if selectionType == "entity"}
 				<h1>
 					{selectedEntity.name}


### PR DESCRIPTION
When enabled, it changes the styling of various elements in order to reduce overall whitespace in the UI, making it look more compact. It also disables the minimap on the right side of the json editor.

Useful in general to be able to see more things at any given time, but especially when having multiple instances of QNE side-by-side.

Disabled:
![Disabled](https://i.nofate.me/Ne26Deey2ZbJyRICwn6p0gG.png)

Enabled:
![Enabled](https://i.nofate.me/6PalUFxE0hYK0cEtGyaNloh.png)