### PR TITLE
Change window title to reflect currently edited entity

### DIFF
--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -3,6 +3,7 @@ import type { Entity } from "$lib/quickentity-types"
 import { getReferencedEntities } from "$lib/utils"
 import Decimal from "decimal.js"
 import { forage } from "@tauri-apps/tauri-forage"
+import { appWindow } from '@tauri-apps/api/window'
 import json from "$lib/json"
 import { Intellisense } from "$lib/intellisense"
 import { v4 } from "uuid"
@@ -98,6 +99,18 @@ export const entity: Writable<Entity> = writable({
 	extraFactoryDependencies: [],
 	extraBlueprintDependencies: [],
 	comments: []
+})
+
+entity.subscribe((value: Entity) => {
+	// Change the title of the window to reflect the currently edited entity
+	// by showing the name of its root entity and its hash. If the root entity
+	// name is "Scene" and the hash is empty, assume that nothing is being edited
+	// and just show "QuickEntity Editor" instead.
+	if (value.entities[value.rootEntity].name !== "Scene" || value.tempHash !== "") {
+		appWindow.setTitle(`${value.entities[value.rootEntity].name} (${value.tempHash}) - QuickEntity Editor`);
+	} else {
+		appWindow.setTitle('QuickEntity Editor');
+	}
 })
 
 export const references: Readable<


### PR DESCRIPTION
When editing an entity, the window title will be set to: 

`<root entity name> (<temphash>) - QuickEntity Editor`

For example, for the agent47_default.entitytemplate entity it would show:

 `Agent47_Default (00D347CBA29EE6BA) - QuickEntity Editor`

This can help with finding the window you're looking for when you have multiple instances of QNE open. If the root name is "Scene" or something generic like that, ideally I would've liked to try to lookup the temp hash in the hashlist and use part of that instead, but I don't know what the best way to do that would be.