### PR TITLE
feat(GUI): add option to hide parents from reverse refs

### DIFF
--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -29,6 +29,8 @@ interface AppSettings {
 
 	technicalMode: boolean
 	compactMode: boolean
+
+	hideParentReverseReferences: boolean
 }
 
 await forage.setItem({

--- a/src/routes/settings.svelte
+++ b/src/routes/settings.svelte
@@ -69,6 +69,8 @@
 		<TextInput labelText="Path to game file data (required)" placeholder={documentsPath + "blabla"} bind:value={$appSettings.gameFileExtensionsDataPath} />
 		<br />
 	{/if}
+	<Checkbox bind:checked={$appSettings.hideParentReverseReferences} labelText="Hide parent reverse references" />
+	<br />
 	<div class="flex items-center gap-2">
 		<div class="flex-shrink">
 			<Checkbox

--- a/src/routes/tree.svelte
+++ b/src/routes/tree.svelte
@@ -395,19 +395,21 @@
 										{#if $reverseReferences[selectedEntityID]?.length}
 											<div class="flex flex-wrap gap-2">
 												{#each $reverseReferences[selectedEntityID] as ref}
-													<ClickableTile
-														on:click={() => {
-															tree.navigateTo(ref.entity)
-														}}
-													>
-														<h4 class="-mt-1">
-															{ref.type.replace(/([A-Z])/g, " $1")[0].toUpperCase() + ref.type.replace(/([A-Z])/g, " $1").slice(1)}
-															<span style="font-size: 1rem;">{ref.context?.join("/") || ""}</span>
-														</h4>
-														{$entity.entities[ref.entity].name} (
-														<code>{ref.entity}</code>
-														)
-													</ClickableTile>
+													{#if ref.type !== 'parent' || !$appSettings.hideParentReverseReferences}
+														<ClickableTile
+															on:click={() => {
+																tree.navigateTo(ref.entity)
+															}}
+														>
+															<h4 class="-mt-1">
+																{ref.type.replace(/([A-Z])/g, " $1")[0].toUpperCase() + ref.type.replace(/([A-Z])/g, " $1").slice(1)}
+																<span style="font-size: 1rem;">{ref.context?.join("/") || ""}</span>
+															</h4>
+															{$entity.entities[ref.entity].name} (
+															<code>{ref.entity}</code>
+															)
+														</ClickableTile>
+													{/if}
 												{/each}
 											</div>
 										{:else}


### PR DESCRIPTION
This adds a checkbox to the options page to hide "Parent" reverse references from the list to improve ease of use due to large elements being flooded with it undermining actually important information.