### PR TITLE
Fix editor message encoding

### DIFF
--- a/src-tauri/src/messages.rs
+++ b/src-tauri/src/messages.rs
@@ -1,5 +1,4 @@
 use serde::{Deserialize, Serialize};
-use serde_with::{serde_as, DisplayFromStr};
 use specta::Type;
 
 #[derive(Serialize, Deserialize, Type)]
@@ -15,7 +14,6 @@ pub struct Transform {
 	pub position: Vec3,
 }
 
-#[serde_as]
 #[derive(Serialize, Deserialize, Type)]
 pub enum ReceivedMessage {
 	Hello {
@@ -23,22 +21,21 @@ pub enum ReceivedMessage {
 	},
 
 	SelectEntity {
-		#[serde_as(as = "DisplayFromStr")]
+		#[serde(serialize_with = "serialize_u64_string")]
 		entity_id: u64,
-		#[serde_as(as = "DisplayFromStr")]
+		#[serde(serialize_with = "serialize_u64_string")]
 		tblu_hash: u64,
 	},
 
 	SetEntityTransform {
-		#[serde_as(as = "DisplayFromStr")]
+		#[serde(serialize_with = "serialize_u64_string")]
 		entity_id: u64,
-		#[serde_as(as = "DisplayFromStr")]
+		#[serde(serialize_with = "serialize_u64_string")]
 		tblu_hash: u64,
 		transform: Transform,
 	},
 }
 
-#[serde_as]
 #[derive(Serialize, Deserialize, Type)]
 pub enum SentMessage {
 	Hello {
@@ -46,35 +43,58 @@ pub enum SentMessage {
 	},
 
 	SelectEntity {
-		#[serde_as(as = "DisplayFromStr")]
+		#[serde(deserialize_with = "deserialize_u64_string")]
 		entity_id: u64,
-		#[serde_as(as = "DisplayFromStr")]
+		#[serde(deserialize_with = "deserialize_u64_string")]
 		tblu_hash: u64,
 	},
 
 	SetEntityTransform {
-		#[serde_as(as = "DisplayFromStr")]
+		#[serde(deserialize_with = "deserialize_u64_string")]
 		entity_id: u64,
-		#[serde_as(as = "DisplayFromStr")]
+		#[serde(deserialize_with = "deserialize_u64_string")]
 		tblu_hash: u64,
 		transform: Transform,
 	},
 
 	SpawnEntity {
-		#[serde_as(as = "DisplayFromStr")]
+		#[serde(deserialize_with = "deserialize_u64_string")]
 		entity_id: u64,
-		#[serde_as(as = "DisplayFromStr")]
+		#[serde(deserialize_with = "deserialize_u64_string")]
 		temp_hash: u64,
 	},
 
 	SetSpawnedEntityTransform {
-		#[serde_as(as = "DisplayFromStr")]
+		#[serde(deserialize_with = "deserialize_u64_string")]
 		entity_id: u64,
 		transform: Transform,
 	},
 
 	DeleteSpawnedEntity {
-		#[serde_as(as = "DisplayFromStr")]
+		#[serde(deserialize_with = "deserialize_u64_string")]
 		entity_id: u64,
 	},
+}
+
+/**
+ * We deserialize u64s from strings for messages sent from JS to Rust,
+ * because JS can't handle u64s.
+ */
+fn deserialize_u64_string<'de, D>(deserializer: D) -> Result<u64, D::Error>
+where
+	D: serde::Deserializer<'de>,
+{
+	let s: String = Deserialize::deserialize(deserializer)?;
+	u64::from_str_radix(&s, 10).map_err(serde::de::Error::custom)
+}
+
+/**
+ * We serialize u64s to strings for messages sent from Rust to JS,
+ * for the same reason.
+ */
+fn serialize_u64_string<S>(x: &u64, serializer: S) -> Result<S::Ok, S::Error>
+where
+	S: serde::Serializer,
+{
+	serializer.serialize_str(&x.to_string())
 }


### PR DESCRIPTION
u64s sent to the editor were being serialized as strings, and u64s received from the editor were also expected to be strings. This adds separate serializers and deserializers to be used on either side respectively.